### PR TITLE
fix(reports): use chapter country for regional breakdowns + render fix on quarterly summary

### DIFF
--- a/reports/_common.R
+++ b/reports/_common.R
@@ -17,6 +17,49 @@ chapters <- read_json(
   simplifyVector = TRUE
 )
 
+# Enrich events with chapter country (chapter, not venue).
+# The chapter country comes from the Meetup GraphQL API and is the
+# canonical "where this chapter is from" — independent of where any
+# given event was held (virtual, traveling speaker, cross-chapter event).
+events <- events |>
+  left_join(
+    chapters |> select(
+      urlname,
+      chapter_country = country,
+      chapter_country_iso = country_acronym
+    ),
+    by = c("group_urlname" = "urlname")
+  )
+
+# Map ISO2 chapter country code to the 6 reporting regions.
+# Uses countrycode's UN sub-region mapping for full country coverage,
+# then collapses to the project's 6 buckets. Returns NA for codes that
+# countrycode cannot resolve; callers decide how to handle NA (e.g.
+# bucket as "Other", filter out, etc.).
+chapter_region <- function(country_iso2) {
+  subregion <- countrycode::countrycode(
+    country_iso2,
+    origin = "iso2c",
+    destination = "un.regionsub.name",
+    warn = FALSE
+  )
+  case_when(
+    subregion == "Northern America" ~ "North America",
+    subregion %in% c("Latin America and the Caribbean") ~ "Latin America",
+    subregion %in% c(
+      "Northern Europe", "Western Europe",
+      "Southern Europe", "Eastern Europe"
+    ) ~ "Europe",
+    subregion %in% c("Australia and New Zealand", "Melanesia",
+                     "Micronesia", "Polynesia") ~ "Oceania",
+    subregion %in% c("Eastern Asia", "South-eastern Asia",
+                     "Southern Asia", "Central Asia", "Western Asia") ~ "Asia",
+    subregion %in% c("Northern Africa", "Sub-Saharan Africa") ~ "Africa",
+    TRUE ~ NA_character_
+  )
+}
+
+
 # R-Ladies brand colors
 rladies_colors <- list(
   purple = "#88398A",

--- a/reports/funder-report.qmd
+++ b/reports/funder-report.qmd
@@ -135,55 +135,13 @@ ggplot(chapter_activity, aes(x = quarter, y = active_chapters)) +
 #| label: geographic-reach
 #| fig-cap: "Event distribution by region"
 
-# Extract country from location (last part after comma)
+# Bucket events by region using the chapter's country (not the venue's).
+# chapter_country_iso is joined in via reports/_common.R. Virtual events
+# are attributed to the region of the chapter that organized them.
 regional_events <- current_events |>
-  filter(!is.na(location)) |>
   mutate(
-    # Extract country code (last 2 characters after last comma)
-    country_code = str_extract(location, "[A-Z]{2}$"),
-    region = case_when(
-      country_code %in% c("US", "CA", "MX") ~ "North America",
-      country_code %in%
-        c(
-          "BR",
-          "AR",
-          "CL",
-          "CO",
-          "PE",
-          "UY",
-          "EC",
-          "BO",
-          "VE"
-        ) ~ "Latin America",
-      country_code %in%
-        c(
-          "GB",
-          "FR",
-          "DE",
-          "ES",
-          "IT",
-          "NL",
-          "BE",
-          "CH",
-          "AT",
-          "IE",
-          "PT",
-          "SE",
-          "NO",
-          "DK",
-          "FI",
-          "PL",
-          "CZ",
-          "GR",
-          "TR"
-        ) ~ "Europe",
-      country_code %in% c("AU", "NZ") ~ "Oceania",
-      country_code %in%
-        c("CN", "JP", "KR", "IN", "SG", "TH", "MY", "ID", "PH", "TW") ~ "Asia",
-      country_code %in% c("ZA", "KE", "NG", "EG", "MA") ~ "Africa",
-      is_virtual ~ "Virtual (Global)",
-      TRUE ~ "Other"
-    )
+    region = chapter_region(chapter_country_iso),
+    region = tidyr::replace_na(region, "Other")
   ) |>
   count(region, sort = TRUE)
 

--- a/reports/geographic-analysis.qmd
+++ b/reports/geographic-analysis.qmd
@@ -134,55 +134,13 @@ ggplot(chapter_activity, aes(x = quarter, y = active_chapters)) +
 #| label: geographic-reach
 #| fig-cap: "Event distribution by region"
 
-# Extract country from location (last part after comma)
+# Bucket events by region using the chapter's country (not the venue's).
+# chapter_country_iso is joined in via reports/_common.R. Virtual events
+# are attributed to the region of the chapter that organized them.
 regional_events <- current_events |>
-  filter(!is.na(location)) |>
   mutate(
-    # Extract country code (last 2 characters after last comma)
-    country_code = str_extract(location, "[A-Z]{2}$"),
-    region = case_when(
-      country_code %in% c("US", "CA", "MX") ~ "North America",
-      country_code %in%
-        c(
-          "BR",
-          "AR",
-          "CL",
-          "CO",
-          "PE",
-          "UY",
-          "EC",
-          "BO",
-          "VE"
-        ) ~ "Latin America",
-      country_code %in%
-        c(
-          "GB",
-          "FR",
-          "DE",
-          "ES",
-          "IT",
-          "NL",
-          "BE",
-          "CH",
-          "AT",
-          "IE",
-          "PT",
-          "SE",
-          "NO",
-          "DK",
-          "FI",
-          "PL",
-          "CZ",
-          "GR",
-          "TR"
-        ) ~ "Europe",
-      country_code %in% c("AU", "NZ") ~ "Oceania",
-      country_code %in%
-        c("CN", "JP", "KR", "IN", "SG", "TH", "MY", "ID", "PH", "TW") ~ "Asia",
-      country_code %in% c("ZA", "KE", "NG", "EG", "MA") ~ "Africa",
-      is_virtual ~ "Virtual (Global)",
-      TRUE ~ "Other"
-    )
+    region = chapter_region(chapter_country_iso),
+    region = tidyr::replace_na(region, "Other")
   ) |>
   count(region, sort = TRUE)
 

--- a/reports/new-chapter-guide.qmd
+++ b/reports/new-chapter-guide.qmd
@@ -280,18 +280,8 @@ ggplot(top_current, aes(x = n, y = reorder(group_urlname, n))) +
 
 regional_current <- current_events |>
   mutate(
-    country_code = str_extract(location, "[A-Z]{2}$"),
-    region = case_when(
-      country_code %in% c("US", "CA", "MX") ~ "North America",
-      country_code %in% c("BR", "AR", "CL", "CO", "PE", "UY") ~ "Latin America",
-      country_code %in%
-        c("GB", "FR", "DE", "ES", "IT", "NL", "BE", "CH", "AT") ~ "Europe",
-      country_code %in% c("AU", "NZ") ~ "Oceania",
-      country_code %in% c("CN", "JP", "KR", "IN", "SG") ~ "Asia",
-      country_code %in% c("ZA", "KE", "NG") ~ "Africa",
-      is_virtual ~ "Virtual (Global)",
-      TRUE ~ "Other"
-    )
+    region = chapter_region(chapter_country_iso),
+    region = tidyr::replace_na(region, "Other")
   ) |>
   filter(region != "Other") |>
   count(region, sort = TRUE) |>

--- a/reports/quarterly-summary.qmd
+++ b/reports/quarterly-summary.qmd
@@ -280,18 +280,8 @@ ggplot(top_current, aes(x = n, y = reorder(group_urlname, n))) +
 
 regional_current <- current_events |>
   mutate(
-    country_code = str_extract(location, "[A-Z]{2}$"),
-    region = case_when(
-      country_code %in% c("US", "CA", "MX") ~ "North America",
-      country_code %in% c("BR", "AR", "CL", "CO", "PE", "UY") ~ "Latin America",
-      country_code %in%
-        c("GB", "FR", "DE", "ES", "IT", "NL", "BE", "CH", "AT") ~ "Europe",
-      country_code %in% c("AU", "NZ") ~ "Oceania",
-      country_code %in% c("CN", "JP", "KR", "IN", "SG") ~ "Asia",
-      country_code %in% c("ZA", "KE", "NG") ~ "Africa",
-      is_virtual ~ "Virtual (Global)",
-      TRUE ~ "Other"
-    )
+    region = chapter_region(chapter_country_iso),
+    region = tidyr::replace_na(region, "Other")
   ) |>
   filter(region != "Other") |>
   count(region, sort = TRUE) |>
@@ -376,7 +366,7 @@ ggplot(chapter_status, aes(x = status, y = count)) +
 
 dow_current <- current_events |>
   mutate(
-    event_datetime = ymd_hms(start, quiet = TRUE),
+    event_datetime = ymd_hms(datetime, quiet = TRUE),
     dow = wday(event_date, label = TRUE, week_start = 1)
   ) |>
   filter(!is.na(dow)) |>


### PR DESCRIPTION
The regional event breakdowns extracted the country from the venue location string with str_extract(location, [A-Z]{2}$). That regex captured the trailing two letters of the country name (uppercase in the location string), not an ISO code, so UNITED STATES OF AMERICA yielded CA, BRAZIL yielded IL, etc. The resulting region buckets were wrong.

Beyond the regex bug, the breakdowns should use the chapter country, not the venue country, for example because virtual events have no venue. Virtual events are now attributed to the region of the chapter that organized them instead of falling into a separate Virtual (Global) bucket.

Changes:
- reports/_common.R: left_join chapters into events to expose chapter_country and chapter_country_iso. Added a chapter_region helper covering the 6 reporting regions (North America, Latin America, Europe, Oceania, Asia, Africa). The helper uses countrycode UN sub-region mapping.
- reports/geographic-analysis.qmd, reports/funder-report.qmd, reports/quarterly-summary.qmd, reports/new-chapter-guide.qmd: replace the per-report regex and case_when blocks with a call to chapter_region(chapter_country_iso).
- reports/quarterly-summary.qmd: fix a preexisting render error in the timing-patterns chunk where ymd_hms(start, ...) referenced a column that doesnt exist. 

This fixes #7 and #6 