### PR TITLE
Quarterly summary review

### DIFF
--- a/reports/quarterly-summary.qmd
+++ b/reports/quarterly-summary.qmd
@@ -446,7 +446,7 @@ metrics_comparison <- tibble(
 
 knitr::kable(
   metrics_comparison,
-  caption = "Key metrics comparison across quarters"
+  caption = "Key metrics comparison across quarters: last closed quarter, prior quarter, and year-ago quarter"
 )
 ```
 

--- a/reports/quarterly-summary.qmd
+++ b/reports/quarterly-summary.qmd
@@ -147,7 +147,7 @@ ggplot(quarterly_data, aes(x = quarter, y = events)) +
   ) +
   labs(
     title = "Event Volume Comparison",
-    subtitle = "Last three quarters",
+    subtitle = "Last three closed quarters",
     x = "Quarter",
     y = "Number of Events"
   ) +
@@ -190,7 +190,7 @@ ggplot(chapter_quarterly, aes(x = quarter, y = chapters)) +
 
 ```{r}
 #| label: format-distribution
-#| fig-cap: "Virtual vs in-person events this quarter"
+#| fig-cap: "Virtual vs in-person events in the last closed quarter"
 
 format_data <- current_events |>
   mutate(format = if_else(is_virtual, "Virtual", "In-Person")) |>
@@ -226,7 +226,7 @@ ggplot(format_data, aes(x = "", y = n, fill = format)) +
 
 ```{r}
 #| label: monthly-activity
-#| fig-cap: "Event activity by month within current quarter"
+#| fig-cap: "Event activity by month within the last closed quarter"
 
 monthly_current <- current_events |>
   mutate(month = floor_date(event_date, "month")) |>
@@ -252,7 +252,7 @@ ggplot(monthly_current, aes(x = month, y = n)) +
 
 ```{r}
 #| label: top-chapters
-#| fig-cap: "Most active chapters this quarter"
+#| fig-cap: "Most active chapters in the last closed quarter"
 
 top_current <- current_events |>
   count(group_urlname, sort = TRUE) |>
@@ -277,7 +277,7 @@ ggplot(top_current, aes(x = n, y = reorder(group_urlname, n))) +
 
 ```{r}
 #| label: regional-performance
-#| fig-cap: "Event distribution by region this quarter"
+#| fig-cap: "Event distribution by region in the last closed quarter"
 
 regional_current <- current_events |>
   mutate(
@@ -363,7 +363,7 @@ ggplot(chapter_status, aes(x = status, y = count)) +
 
 ```{r}
 #| label: timing-patterns
-#| fig-cap: "Day of week distribution this quarter"
+#| fig-cap: "Day of week distribution in the last closed quarter"
 
 dow_current <- current_events |>
   mutate(
@@ -457,7 +457,7 @@ knitr::kable(
 Based on current trends and historical patterns:
 
 - Expected events next quarter: **`r round(current_total * 1.05)`** (assuming 5% growth)  
-- Chapters needing support: **`r nrow(inactive_chapters)`** (became inactive this quarter)  
+- Chapters needing support: **`r nrow(inactive_chapters)`** (became inactive in the last closed quarter)  
 - Growth opportunity: Focus on `r if(nrow(new_chapters) > 0) paste("sustaining momentum of", nrow(new_chapters), "new/reactivated chapters") else "reactivating dormant chapters"`  
 
 ### Recommendations

--- a/reports/quarterly-summary.qmd
+++ b/reports/quarterly-summary.qmd
@@ -26,8 +26,9 @@ This quarterly report provides a snapshot of R-Ladies community activity, highli
 
 ```{r}
 #| label: quarterly-metrics
-# Define current and previous quarters
-current_quarter_end <- floor_date(Sys.Date(), "quarter") + months(3) - days(1)
+# Define reporting quarters: current = last closed quarter, plus the
+# preceding quarter and the same quarter one year earlier for comparison.
+current_quarter_end <- floor_date(Sys.Date(), "quarter") - days(1)
 current_quarter_start <- floor_date(current_quarter_end, "quarter")
 
 previous_quarter_end <- current_quarter_start - days(1)
@@ -105,9 +106,9 @@ year_ago_q <- paste0(
 )
 ```
 
-### Quarter: `r current_q`
+### Quarter: `r current_q` (last closed quarter)
 
-**Period**: `r format(current_quarter_start, "%B %d")` - `r format(current_quarter_end, "%B %d, %Y")`
+**Period** (last closed quarter): `r format(current_quarter_start, "%B %d")` - `r format(current_quarter_end, "%B %d, %Y")`
 
 - **Total Events**: `r format(current_total, big.mark = ",")`  
   - Quarter-over-quarter: `r if_else(qoq_growth >= 0, paste0("+", qoq_growth), as.character(qoq_growth))`%  
@@ -468,6 +469,6 @@ Based on current trends and historical patterns:
 
 ---
 
-*Report period: `r format(current_quarter_start, "%B %d")` - `r format(current_quarter_end, "%B %d, %Y")`*  
+*Report period (last closed quarter): `r format(current_quarter_start, "%B %d")` - `r format(current_quarter_end, "%B %d, %Y")`*  
 *Report generated: `r format(Sys.time(), "%Y-%m-%d %H:%M %Z")`*  
 *Data source: R-Ladies Meetup Archive*


### PR DESCRIPTION
The report used the in-progress quarter while QoQ/YoY compared against full quarters — a partial vs. complete comparison. This moves the reporting quarter to the last closed quarter; `previous` and `year_ago` shift in cascade, so all charts, tables and growth metrics inherit the fix.

## Changes

- Reporting quarter = last closed quarter (was in-progress).
- Clarify "last closed quarter" across headers, captions, subtitles and footer.
- Reword the performance-indicators table caption.